### PR TITLE
Add title/description to mobile sidebar sheet

### DIFF
--- a/src/components/ui/sidebar/Sidebar.vue
+++ b/src/components/ui/sidebar/Sidebar.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { SidebarProps } from '.'
 import { cn } from '@/lib/utils'
-import { Sheet, SheetContent } from '@/components/ui/sheet'
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetDescription } from '@/components/ui/sheet'
 import { SIDEBAR_WIDTH_MOBILE, useSidebar } from './utils'
 
 defineOptions({
@@ -36,6 +36,10 @@ const { isMobile, state, openMobile, setOpenMobile } = useSidebar()
         '--sidebar-width': SIDEBAR_WIDTH_MOBILE,
       }"
     >
+      <SheetHeader class="px-6 pb-0 pt-4">
+        <SheetTitle>Menu</SheetTitle>
+        <SheetDescription>Abrir navegação</SheetDescription>
+      </SheetHeader>
       <div class="flex h-full w-full flex-col">
         <slot />
       </div>


### PR DESCRIPTION
## Summary
- include `SheetHeader`, `SheetTitle`, and `SheetDescription` in `Sidebar.vue`
- import the new components

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859a8752648832d8d9a8041149fc53a