### PR TITLE
Fix warning by adding sheet description

### DIFF
--- a/src/components/ui/sidebar/Sidebar.vue
+++ b/src/components/ui/sidebar/Sidebar.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { SidebarProps } from '.'
 import { cn } from '@/lib/utils'
-import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'
+import { Sheet, SheetContent, SheetTitle, SheetDescription } from '@/components/ui/sheet'
 import { VisuallyHidden } from 'reka-ui'
 import { SIDEBAR_WIDTH_MOBILE, useSidebar } from './utils'
 
@@ -39,6 +39,7 @@ const { isMobile, state, openMobile, setOpenMobile } = useSidebar()
     >
       <VisuallyHidden>
         <SheetTitle>Sidebar</SheetTitle>
+        <SheetDescription>Navigation sidebar</SheetDescription>
       </VisuallyHidden>
       <div class="flex h-full w-full flex-col">
         <slot />


### PR DESCRIPTION
## Summary
- import `SheetDescription` in the sidebar component
- include hidden description for mobile SheetContent

## Testing
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_6859c6a16a18832da1e88c80845b6e09