### PR TITLE
Add signup and reset password

### DIFF
--- a/src/components/ForgotPasswordForm.vue
+++ b/src/components/ForgotPasswordForm.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { auth } from '@/control/firebase'
+import { sendPasswordResetEmail } from 'firebase/auth'
+
+const email = ref('')
+const sent = ref(false)
+
+async function onSubmit() {
+  try {
+    await sendPasswordResetEmail(auth, email.value)
+    sent.value = true
+  } catch (err) {
+    console.error(err)
+  }
+}
+</script>
+
+<template>
+  <form @submit.prevent="onSubmit">
+    <Card class="mx-auto max-w-sm">
+      <CardHeader>
+        <CardTitle class="text-2xl">Reset Password</CardTitle>
+        <CardDescription>Enter your email to reset your password</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div v-if="!sent" class="grid gap-4">
+          <div class="grid gap-2">
+            <Label for="email">Email</Label>
+            <Input id="email" type="email" placeholder="m@example.com" v-model="email" required />
+          </div>
+          <Button type="submit" class="w-full">Send Reset Email</Button>
+        </div>
+        <p v-else class="text-center">A password reset link has been sent to your email.</p>
+        <div class="mt-4 text-center text-sm">
+          <router-link to="/login" class="underline">Back to login</router-link>
+        </div>
+      </CardContent>
+    </Card>
+  </form>
+</template>

--- a/src/components/LoginForm.vue
+++ b/src/components/LoginForm.vue
@@ -65,9 +65,12 @@ async function loginWithGoogle() {
           <div class="grid gap-2">
             <div class="flex items-center">
               <Label for="password">Password</Label>
-              <a href="#" class="ml-auto inline-block text-sm underline">
+              <router-link
+                to="/forgot-password"
+                class="ml-auto inline-block text-sm underline"
+              >
                 Forgot your password?
-              </a>
+              </router-link>
             </div>
             <Input id="password" type="password" v-model="password" required />
           </div>
@@ -78,7 +81,7 @@ async function loginWithGoogle() {
         </div>
         <div class="mt-4 text-center text-sm">
           Don't have an account?
-          <a href="#" class="underline"> Sign up </a>
+          <router-link to="/signup" class="underline"> Sign up </router-link>
         </div>
       </CardContent>
     </Card>

--- a/src/components/SignupForm.vue
+++ b/src/components/SignupForm.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { auth } from '@/control/firebase'
+import { createUserWithEmailAndPassword } from 'firebase/auth'
+
+const router = useRouter()
+const route = useRoute()
+
+const email = ref('')
+const password = ref('')
+
+async function onSubmit() {
+  try {
+    await createUserWithEmailAndPassword(auth, email.value, password.value)
+    const redirect = (route.query.redirect as string) || '/p/dashboard'
+    router.replace(redirect)
+  } catch (err) {
+    console.error(err)
+  }
+}
+</script>
+
+<template>
+  <form @submit.prevent="onSubmit">
+    <Card class="mx-auto max-w-sm">
+      <CardHeader>
+        <CardTitle class="text-2xl">Sign Up</CardTitle>
+        <CardDescription>Create a new account</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div class="grid gap-4">
+          <div class="grid gap-2">
+            <Label for="email">Email</Label>
+            <Input
+              id="email"
+              type="email"
+              placeholder="m@example.com"
+              v-model="email"
+              required
+            />
+          </div>
+          <div class="grid gap-2">
+            <Label for="password">Password</Label>
+            <Input id="password" type="password" v-model="password" required />
+          </div>
+          <Button type="submit" class="w-full">Sign Up</Button>
+        </div>
+        <div class="mt-4 text-center text-sm">
+          Already have an account?
+          <router-link to="/login" class="underline">Log in</router-link>
+        </div>
+      </CardContent>
+    </Card>
+  </form>
+</template>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -3,6 +3,8 @@ import type { RouteRecordRaw } from "vue-router";
 import { auth } from "@/control/firebase";
 
 import AuthView from "@/views/AuthView.vue";
+import SignUpView from "@/views/SignUpView.vue";
+import ForgotPasswordView from "@/views/ForgotPasswordView.vue";
 import Dashboard from "@/views/Dashboard.vue";
 import PublicStart from "@/views/PublicStart.vue";
 import NotFound from "@/views/NotFound.vue";
@@ -22,6 +24,16 @@ const routes: RouteRecordRaw[] = [
     path: "/login",
     name: "login",
     component: AuthView,
+  },
+  {
+    path: "/signup",
+    name: "signup",
+    component: SignUpView,
+  },
+  {
+    path: "/forgot-password",
+    name: "forgot-password",
+    component: ForgotPasswordView,
   },
   {
     path: "/p/dashboard",

--- a/src/views/ForgotPasswordView.vue
+++ b/src/views/ForgotPasswordView.vue
@@ -1,0 +1,11 @@
+<template>
+  <div class="flex size-screen justify-center items-center">
+    <ForgotPasswordForm />
+  </div>
+</template>
+
+<script setup lang="ts">
+import ForgotPasswordForm from '@/components/ForgotPasswordForm.vue'
+</script>
+
+<style scoped></style>

--- a/src/views/SignUpView.vue
+++ b/src/views/SignUpView.vue
@@ -1,0 +1,11 @@
+<template>
+  <div class="flex size-screen justify-center items-center">
+    <SignupForm />
+  </div>
+</template>
+
+<script setup lang="ts">
+import SignupForm from '@/components/SignupForm.vue'
+</script>
+
+<style scoped></style>


### PR DESCRIPTION
## Summary
- add a signup form and view
- add password reset form and view
- expose `/signup` and `/forgot-password` routes
- link to the new routes from the login form

## Testing
- `pnpm run build`

------
https://chatgpt.com/codex/tasks/task_e_6859ca4f4090832dab0a12d17ccc84c3