### PR TITLE
Restructure router with /p and /public paths

### DIFF
--- a/src/components/NavUser.vue
+++ b/src/components/NavUser.vue
@@ -46,7 +46,7 @@ const router = useRouter()
 async function logout() {
   try {
     await signOut(auth)
-    router.push('/login')
+    router.push('/public/login')
   } catch (err) {
     console.error(err)
   }

--- a/src/layouts/SidebarLayout.vue
+++ b/src/layouts/SidebarLayout.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+import AppSidebar from '@/components/AppSidebar.vue'
+import { SidebarProvider, SidebarInset } from '@/components/ui/sidebar'
+</script>
+
+<template>
+  <SidebarProvider>
+    <AppSidebar />
+    <SidebarInset class="flex-1 flex flex-col">
+      <router-view />
+    </SidebarInset>
+  </SidebarProvider>
+</template>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -7,6 +7,7 @@ import Dashboard from "@/views/Dashboard.vue";
 import PublicStart from "@/views/PublicStart.vue";
 import NotFound from "@/views/NotFound.vue";
 import AddAccount from "@/views/accounts/AddAccount.vue";
+import SidebarLayout from "@/layouts/SidebarLayout.vue";
 
 const routes: RouteRecordRaw[] = [
   {
@@ -19,21 +20,26 @@ const routes: RouteRecordRaw[] = [
     component: PublicStart,
   },
   {
-    path: "/login",
+    path: "/public/login",
     name: "login",
     component: AuthView,
   },
   {
-    path: "/p/dashboard",
-    name: "dashboard",
-    component: Dashboard,
+    path: "/p",
+    component: SidebarLayout,
     meta: { requiresAuth: true },
-  },
-  {
-    path: "/p/account/add",
-    name: "add-account",
-    component: AddAccount,
-    meta: { requiresAuth: true },
+    children: [
+      {
+        path: "dashboard",
+        name: "dashboard",
+        component: Dashboard,
+      },
+      {
+        path: "account/add",
+        name: "add-account",
+        component: AddAccount,
+      },
+    ],
   },
   {
     path: "/:pathMatch(.*)*",
@@ -52,12 +58,12 @@ router.beforeEach((to) => {
 
   if (to.meta.requiresAuth && !isAuthenticated) {
     return {
-      path: "/login",
+      path: "/public/login",
       query: { redirect: to.fullPath },
     };
   }
 
-  if (to.path === "/login" && isAuthenticated) {
+  if (to.path === "/public/login" && isAuthenticated) {
     return "/p/dashboard";
   }
 });

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -5,7 +5,6 @@ export const containerClass = "w-full h-full";
 </script>
 
 <script setup lang="ts">
-import AppSidebar from "@/components/AppSidebar.vue";
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -16,45 +15,38 @@ import {
 } from "@/components/ui/breadcrumb";
 import { Separator } from "@/components/ui/separator";
 import {
-  SidebarInset,
-  SidebarProvider,
   SidebarTrigger,
 } from "@/components/ui/sidebar";
 </script>
 
 <template>
-  <SidebarProvider>
-    <AppSidebar />
-    <SidebarInset>
-      <header
-        class="flex h-16 shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-[[data-collapsible=icon]]/sidebar-wrapper:h-12"
-      >
-        <div class="flex items-center gap-2 px-4">
-          <SidebarTrigger class="-ml-1" />
-          <Separator orientation="vertical" class="mr-2 h-4" />
-          <Breadcrumb>
-            <BreadcrumbList>
-              <BreadcrumbItem class="hidden md:block">
-                <BreadcrumbLink href="#">
-                  Building Your Application
-                </BreadcrumbLink>
-              </BreadcrumbItem>
-              <BreadcrumbSeparator class="hidden md:block" />
-              <BreadcrumbItem>
-                <BreadcrumbPage>Data Fetching</BreadcrumbPage>
-              </BreadcrumbItem>
-            </BreadcrumbList>
-          </Breadcrumb>
-        </div>
-      </header>
-      <div class="flex flex-1 flex-col gap-4 p-4 pt-0">
-        <div class="grid auto-rows-min gap-4 md:grid-cols-3">
-          <div class="aspect-video rounded-xl bg-muted/50" />
-          <div class="aspect-video rounded-xl bg-muted/50" />
-          <div class="aspect-video rounded-xl bg-muted/50" />
-        </div>
-        <div class="min-h-[100vh] flex-1 rounded-xl bg-muted/50 md:min-h-min" />
+  <div>
+    <header
+      class="flex h-16 shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-[[data-collapsible=icon]]/sidebar-wrapper:h-12"
+    >
+      <div class="flex items-center gap-2 px-4">
+        <SidebarTrigger class="-ml-1" />
+        <Separator orientation="vertical" class="mr-2 h-4" />
+        <Breadcrumb>
+          <BreadcrumbList>
+            <BreadcrumbItem class="hidden md:block">
+              <BreadcrumbLink href="#">Building Your Application</BreadcrumbLink>
+            </BreadcrumbItem>
+            <BreadcrumbSeparator class="hidden md:block" />
+            <BreadcrumbItem>
+              <BreadcrumbPage>Data Fetching</BreadcrumbPage>
+            </BreadcrumbItem>
+          </BreadcrumbList>
+        </Breadcrumb>
       </div>
-    </SidebarInset>
-  </SidebarProvider>
+    </header>
+    <div class="flex flex-1 flex-col gap-4 p-4 pt-0">
+      <div class="grid auto-rows-min gap-4 md:grid-cols-3">
+        <div class="aspect-video rounded-xl bg-muted/50" />
+        <div class="aspect-video rounded-xl bg-muted/50" />
+        <div class="aspect-video rounded-xl bg-muted/50" />
+      </div>
+      <div class="min-h-[100vh] flex-1 rounded-xl bg-muted/50 md:min-h-min" />
+    </div>
+  </div>
 </template>

--- a/src/views/PublicStart.vue
+++ b/src/views/PublicStart.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flex flex-col items-center justify-center min-h-screen gap-4">
     <h1 class="text-3xl font-bold">Bem-vindo</h1>
-    <RouterLink to="/login" class="text-blue-500 underline">Ir para Login</RouterLink>
+    <RouterLink to="/public/login" class="text-blue-500 underline">Ir para Login</RouterLink>
   </div>
 </template>
 


### PR DESCRIPTION
## Summary
- add SidebarLayout
- nest authenticated pages under `/p` with SidebarLayout
- move login to `/public/login`
- update logout link and public start page
- clean up dashboard layout

## Testing
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_6859cab8727c832db4e46ba0e7c8bfd5